### PR TITLE
Fix bug where GA metric and dimension type is always string

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -55,7 +55,7 @@ class GoogleAnalyticsStream(Stream):
             #  self.dimensions_ref. They are always strings
             return "string"
         elif attribute in dimensions_ref:
-            return self._parse_other_attrb_type(attribute)
+            return self._parse_other_attrb_type(dimensions_ref[attribute])
         else:
             self.logger.critical(f"Unsuported GA type: {type}")
             sys.exit(1)

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -83,7 +83,7 @@ class GoogleAnalyticsStream(Stream):
         elif attribute.startswith(("ga:metric", "ga:calcMetric")):
             return "string"
         elif attribute in metrics_ref:
-            return self._parse_other_attrb_type(attribute)
+            return self._parse_other_attrb_type(metrics_ref[attribute])
         else:
             self.logger.critical(f"Unsuported GA type: {type}")
             sys.exit(1)


### PR DESCRIPTION
`_parse_other_attrb_type` expects a type to be passed in, not attribute name.