### PR TITLE
Allow including view_id in output to disambiguate multiple GA properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-google-analytics"
-version = "0.0.5"
+version = "0.0.6"
 description = "`tap-google-analytics` is a Singer tap for GoogleAnalytics, built with the Meltano SDK for Singer Taps."
 authors = ["Pat Nadolny"]
 keywords = [

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -403,11 +403,16 @@ class GoogleAnalyticsStream(Stream):
         #  {start_date, end_date} params as keys
         if not date_dimension_included:
             self.logger.warn(
-                f"Incrmental sync not supported for stream {self.tap_stream_id}, \
+                f"Incremental sync not supported for stream {self.tap_stream_id}, \
                     'ga.date' is the only supported replication key at this time."
             )
             primary_keys.append("report_start_date")
             primary_keys.append("report_end_date")
+
+        if self.include_view_id_in_output:
+            properties.append(
+                th.Property("include_view_id_in_output", th.BooleanType(), required=False, default=False)
+            )
 
         self.primary_keys = primary_keys
         return th.PropertiesList(*properties).to_dict()

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -38,6 +38,7 @@ class GoogleAnalyticsStream(Stream):
         self.quota_user = self.config.get("quota_user", None)
         self.end_date = self._get_end_date()
         self.view_id = self.config["view_id"]
+        self.include_view_id_in_output: bool = self.config.get("include_view_id_in_output", False)
 
     def _get_end_date(self):
         end_date = self.config.get("end_date", datetime.utcnow().strftime("%Y-%m-%d"))
@@ -286,6 +287,10 @@ class GoogleAnalyticsStream(Stream):
                 # Also add the [start_date,end_date) used for the report
                 record["report_start_date"] = self.config.get("start_date")
                 record["report_end_date"] = self.end_date
+
+                # if configured, include view_id to allow disambiguating multiple Google Analytics views
+                if self.include_view_id_in_output:
+                    record["_view_id"] = self.view_id
 
                 yield record
 

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -411,7 +411,7 @@ class GoogleAnalyticsStream(Stream):
 
         if self.include_view_id_in_output:
             properties.append(
-                th.Property("include_view_id_in_output", th.BooleanType(), required=False, default=False)
+                th.Property("_view_id", th.StringType(), required=False)
             )
 
         self.primary_keys = primary_keys

--- a/tap_google_analytics/tap.py
+++ b/tap_google_analytics/tap.py
@@ -83,6 +83,13 @@ class TapGoogleAnalytics(Tap):
             th.StringType,
             description="The last record date to sync",
         ),
+        th.Property(
+            "include_view_id_in_output",
+            th.BooleanType,
+            description="Include view_id property in output to allow disambiguation of multiple Google Analytics properties",
+            required=False,
+            default=False,
+        ),
     ).to_dict()
 
     def _initialize_credentials(self):


### PR DESCRIPTION
See some more discussion here: https://github.com/meltano/meltano/issues/7165#issuecomment-1397105636

I am trying to set things up to use tap-google-analytics to load 49 GA properties into Redshift. As things stand today there's no information in the records from this tap that associates it with a specific GA property. This PR is an attempt to provide the ability to disambiguate them.

I'm not sure this is the best way, so feedback is very welcome!