### PR TITLE
fix: increase dimensions limit to 9

### DIFF
--- a/tap_google_analytics/tap.py
+++ b/tap_google_analytics/tap.py
@@ -217,9 +217,9 @@ class TapGoogleAnalytics(Tap):
                 )
                 sys.exit(1)
 
-            if len(dimensions) > 7:  # noqa: PLR2004
+            if len(dimensions) > 9:  # noqa: PLR2004
                 self.logger.critical(
-                    "'%s' has too many dimensions defined. GA reports can have maximum 7 "
+                    "'%s' has too many dimensions defined. GA reports can have maximum 9 "
                     "dimensions.",
                     name,
                 )


### PR DESCRIPTION
Currently this tap only allows a maximum of 7 dimensions per report, even though the actual limit is 9.
[Docs](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/Dimension):
> Requests are allowed up to 9 dimensions.