### PR TITLE
Add quota management for GA4 API

### DIFF
--- a/tap_google_analytics/error.py
+++ b/tap_google_analytics/error.py
@@ -69,6 +69,15 @@ def error_reason(e):
 LOGGER = logging.getLogger("googleapiclient.discovery_cache")
 LOGGER.setLevel(logging.ERROR)
 
+def is_quota_error(error):
+    """Return True if error is related to quota exhaustion."""
+    reason = error_reason(error)
+    error_message = str(error).lower()
+    
+    # Check both the reason code and error message content
+    return (reason in ["quotaExceeded", "dailyQuotaExceeded", "userRateLimitExceeded"] or
+            "exhausted property tokens" in error_message or
+            "quota exceeded" in error_message)
 
 def is_fatal_error(error):
     """Return a boolean value depending on if its a fatal error or not."""

--- a/tap_google_analytics/quota_manager.py
+++ b/tap_google_analytics/quota_manager.py
@@ -1,0 +1,15 @@
+from datetime import datetime, timedelta
+import time
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+class QuotaManager:
+    def wait_for_quota_reset(self):
+        """Wait until the next hour when quota resets."""
+        current_time = datetime.now()
+        next_hour = current_time.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        wait_seconds = (next_hour - current_time).total_seconds()
+        
+        LOGGER.info(f"GA4 API quota exhausted. Waiting {wait_seconds:.0f} seconds until {next_hour}")
+        time.sleep(wait_seconds)

--- a/tests/test_quota_management.py
+++ b/tests/test_quota_management.py
@@ -1,0 +1,73 @@
+"""Tests for quota management functionality."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+from tap_google_analytics.quota_manager import QuotaManager
+from tap_google_analytics.error import is_quota_error
+from tap_google_analytics.client import GoogleAnalyticsStream
+
+def test_quota_error_detection():
+    """Test different quota error scenarios."""
+    with patch('tap_google_analytics.error.error_reason') as mock_error_reason:
+        # Test property tokens exhausted
+        error = MagicMock()
+        mock_error_reason.return_value = "quotaExceeded"
+        error.content = b"Exhausted property tokens for a project per hour"
+        assert is_quota_error(error) is True
+
+        # Test regular error
+        mock_error_reason.return_value = "otherError"
+        error.content = b"Some other error"
+        assert is_quota_error(error) is False
+
+def test_quota_manager_wait():
+    """Test quota manager waiting logic."""
+    with patch('time.sleep') as mock_sleep:
+        with patch('datetime.datetime') as mock_datetime:
+            # Mock current time to 2:30 PM
+            current_time = datetime(2024, 1, 1, 14, 30, 0)
+            mock_datetime.now.return_value = current_time
+            
+            quota_manager = QuotaManager()
+            quota_manager.wait_for_quota_reset()
+            
+            # Verify sleep was called with some wait time
+            mock_sleep.assert_called_once()
+
+def test_query_api_retry_logic():
+    """Test the retry logic in _query_api."""
+    mock_tap = MagicMock()
+    mock_tap.config = {"property_id": "123456"}
+    
+    mock_report = {
+        "dimensions": [],
+        "metrics": [],
+        "metricFilter": None,
+        "dimensionFilter": None
+    }
+    
+    stream = GoogleAnalyticsStream(
+        tap=mock_tap,
+        name="test_stream",
+        ga_report=mock_report,  # Use the complete mock report
+        ga_dimensions_ref={},
+        ga_metrics_ref={},
+        ga_analytics_client=MagicMock()
+    )
+    
+    # Mock quota error response
+    error = MagicMock()
+    error.reason = "quotaExceeded"
+    error.content = b"Exhausted property tokens for a project per hour"
+    
+    with patch.object(stream.analytics, 'run_report') as mock_run_report:
+        # First call raises quota error, second call succeeds
+        mock_run_report.side_effect = [
+            error,  # First call
+            MagicMock()  # Second call
+        ]
+        
+        with patch.object(stream.quota_manager, 'wait_for_quota_reset'):
+            # Call the method with the complete mock report
+            stream._query_api(mock_report, "2024-01-01")


### PR DESCRIPTION
Feature: add quota management for GA4 API
- Add QuotaManager class to handle hourly quota resets
- Add retry logic with max attempts for quota errors
- Add error detection for GA4 quota errors
- Wait for quota reset when limits are hit
- Add logging for quota retries

This change helps prevent pipeline failures due to GA4 API quota limits by waiting for quota resets and retrying automatically.