### PR TITLE
chore: pin GitHub Actions versions to commit hashes

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -11,11 +11,11 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: 3.x
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
       with:
         version: ">=0.4.18"
     - run: uvx tox -e lint
@@ -36,12 +36,12 @@ jobs:
         - "3.13"
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
       with:
         version: ">=0.4.18"
     - run: uvx tox -e $(echo py${{ matrix.python-version }} | tr -d .)

--- a/.github/workflows/project_add.yml
+++ b/.github/workflows/project_add.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/MeltanoLabs/projects/3
           github-token: ${{ secrets.MELTYBOT_PROJECT_ADD_PAT }}


### PR DESCRIPTION
This will help prevent attacks such as [this one](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/).

Dependabot is able to update these versions automatically, and it will preserve the readable version comments.
