### PR TITLE
fix: Handle empty dimension values with appropriate defaults

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import copy
-import datetime
 import functools
 import sys
 import typing as t
-from datetime import date, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import backoff
 from google.analytics.data_v1beta.types import (
@@ -46,16 +45,12 @@ class GoogleAnalyticsStream(Stream):
         self.property_id = self.config["property_id"]
         self.page_size = 100000
 
-    @staticmethod
-    def _parse_iso_timestamp(input_ts: str) -> datetime.datetime:
-        return datetime.datetime.fromisoformat(input_ts.replace("Z", "+00:00"))
-
     def _get_end_date(self):
         end_date_config = self.config.get("end_date")
         end_date = (
-            self._parse_iso_timestamp(end_date_config)
+            datetime.fromisoformat(end_date_config).date()
             if end_date_config
-            else datetime.datetime.now(timezone.utc)
+            else datetime.now(timezone.utc).date()
         )
         end_date_offset = end_date - timedelta(days=1)
 
@@ -149,7 +144,7 @@ class GoogleAnalyticsStream(Stream):
     def _get_state_filter(self, context: Context | None) -> str:
         state = self.get_context_state(context)
         state_bookmark = state.get("replication_key_value") or self.config["start_date"]
-        parsed = self._parse_iso_timestamp(state_bookmark).date()
+        parsed = datetime.fromisoformat(state_bookmark).date()
         parsed = max(parsed, date(2019, 1, 1))
 
         # state bookmarks need to be reformatted for API requests

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -212,15 +212,11 @@ class GoogleAnalyticsStream(Stream):
             "dimension", dimension_name, self.dimensions_ref, self.metrics_ref
         )
 
-        # Dimensions participate in stream keys, so coerce missing values
-        # to the GA-style placeholder so database loaders do not reject nulls.
-        value = raw_value or "(not set)"
-
         if data_type == "integer":
-            return int(value)
+            return int(raw_value) if raw_value else 0
         if data_type == "number":
-            return float(value)
-        return value
+            return float(raw_value) if raw_value else 0.0
+        return raw_value or "(not set)"
 
     def _parse_metric_value(self, metric_name: str, raw_value: t.Any) -> t.Any:
         metric_type = self._lookup_data_type(

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -143,7 +143,8 @@ class GoogleAnalyticsStream(Stream):
 
     def _get_state_filter(self, context: Context | None) -> str:
         state = self.get_context_state(context)
-        state_bookmark = state.get("replication_key_value") or self.config["start_date"]
+        state_bookmark = state.get(
+            "replication_key_value") or self.config["start_date"]
         parsed = datetime.fromisoformat(state_bookmark).date()
         parsed = max(parsed, date(2019, 1, 1))
 
@@ -207,37 +208,41 @@ class GoogleAnalyticsStream(Stream):
         total_rows = response.row_count
         return next_token if total_rows >= next_token * self.page_size else None
 
-    def _parse_dimension_value(self, header: str, raw_dimension: t.Any) -> t.Any:
+    def _parse_dimension_value(self, dimension_name: str, raw_value: t.Any) -> t.Any:
         data_type = self._lookup_data_type(
-            "dimension", header, self.dimensions_ref, self.metrics_ref
+            "dimension", dimension_name, self.dimensions_ref, self.metrics_ref
         )
 
-        # Keep deviceModel in the primary key, but coerce missing values
-        # to the GA-style placeholder so Postgres does not reject nulls.
-        normalized_dimension = (
+        # Dimensions participate in stream keys, so coerce missing values
+        # to the GA-style placeholder so database loaders do not reject nulls.
+        value = (
             "(not set)"
-            if header == "deviceModel" and raw_dimension in ("", None)
-            else raw_dimension
+            if not raw_value
+            else raw_value
         )
 
         if data_type == "integer":
-            return int(normalized_dimension)
+            return int(value)
         if data_type == "number":
-            return float(normalized_dimension)
-        return normalized_dimension
+            return float(value)
+        return value
 
     def _parse_metric_value(self, metric_name: str, raw_value: t.Any) -> t.Any:
         metric_type = self._lookup_data_type(
-            "metric", metric_name, self.dimensions_ref, self.metrics_ref
+            "metric",
+            metric_name,
+            self.dimensions_ref,
+            self.metrics_ref
         )
 
-        normalized_value = raw_value.value if hasattr(raw_value, "value") else raw_value
+        value = raw_value.value if hasattr(
+            raw_value, "value") else raw_value
 
         if metric_type == "integer":
-            return int(normalized_value)
+            return int(value)
         if metric_type == "number":
-            return float(normalized_value)
-        return normalized_value
+            return float(value)
+        return value
 
     def _parse_response(self, response):
         if not response:
@@ -251,10 +256,12 @@ class GoogleAnalyticsStream(Stream):
             dateRangeValues = row.metric_values  # noqa: N806
 
             for header, raw_dimension in zip(dimensionHeaders, dimensions):
-                record[header] = self._parse_dimension_value(header, raw_dimension)
+                record[header] = self._parse_dimension_value(
+                    header, raw_dimension)
 
             for metric_name, raw_value in zip(metricHeaders, dateRangeValues):
-                record[metric_name] = self._parse_metric_value(metric_name, raw_value)
+                record[metric_name] = self._parse_metric_value(
+                    metric_name, raw_value)
 
             # Also add the [start_date,end_date) used for the report
             record["report_start_date"] = self.config.get("start_date")
@@ -273,7 +280,8 @@ class GoogleAnalyticsStream(Stream):
             property=f"properties/{self.property_id}",
             dimensions=report_definition["dimensions"],
             metrics=report_definition["metrics"],
-            date_ranges=[DateRange(start_date=state_filter, end_date=self.end_date)],
+            date_ranges=[
+                DateRange(start_date=state_filter, end_date=self.end_date)],
             limit=self.page_size,
             metric_filter=report_definition["metricFilter"],
             dimension_filter=report_definition["dimensionFilter"],
@@ -327,7 +335,8 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "dimension", dimension, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(dimension, self._get_datatype(data_type), required=True))
+            properties.append(th.Property(
+                dimension, self._get_datatype(data_type), required=True))
             primary_keys.append(dimension)
 
         # Add the metrics to the schema
@@ -335,11 +344,13 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "metric", metric, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(metric, self._get_datatype(data_type)))
+            properties.append(th.Property(
+                metric, self._get_datatype(data_type)))
 
         properties.extend(
             (
-                th.Property("report_start_date", th.StringType(), required=True),
+                th.Property("report_start_date",
+                            th.StringType(), required=True),
                 th.Property("report_end_date", th.StringType(), required=True),
             )
         )

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -223,6 +223,11 @@ class GoogleAnalyticsStream(Stream):
                     "dimension", header, self.dimensions_ref, self.metrics_ref
                 )
 
+                # Keep deviceModel in the primary key, but coerce missing values
+                # to the GA-style placeholder so Postgres does not reject nulls.
+                if header == "deviceModel" and dimension in ("", None):
+                    dimension = "(not set)"
+
                 if data_type == "integer":
                     value = int(dimension)
                 elif data_type == "number":

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import copy
+import datetime
 import functools
 import sys
 import typing as t
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, timedelta, timezone
 
 import backoff
 from google.analytics.data_v1beta.types import (
@@ -45,12 +46,16 @@ class GoogleAnalyticsStream(Stream):
         self.property_id = self.config["property_id"]
         self.page_size = 100000
 
+    @staticmethod
+    def _parse_iso_timestamp(input_ts: str) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(input_ts.replace("Z", "+00:00"))
+
     def _get_end_date(self):
         end_date_config = self.config.get("end_date")
         end_date = (
-            datetime.strptime(end_date_config, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            self._parse_iso_timestamp(end_date_config)
             if end_date_config
-            else datetime.now(timezone.utc)
+            else datetime.datetime.now(timezone.utc)
         )
         end_date_offset = end_date - timedelta(days=1)
 
@@ -144,7 +149,7 @@ class GoogleAnalyticsStream(Stream):
     def _get_state_filter(self, context: Context | None) -> str:
         state = self.get_context_state(context)
         state_bookmark = state.get("replication_key_value") or self.config["start_date"]
-        parsed = date.fromisoformat(state_bookmark)
+        parsed = self._parse_iso_timestamp(state_bookmark).date()
         parsed = max(parsed, date(2019, 1, 1))
 
         # state bookmarks need to be reformatted for API requests

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -143,8 +143,7 @@ class GoogleAnalyticsStream(Stream):
 
     def _get_state_filter(self, context: Context | None) -> str:
         state = self.get_context_state(context)
-        state_bookmark = state.get(
-            "replication_key_value") or self.config["start_date"]
+        state_bookmark = state.get("replication_key_value") or self.config["start_date"]
         parsed = datetime.fromisoformat(state_bookmark).date()
         parsed = max(parsed, date(2019, 1, 1))
 
@@ -215,11 +214,7 @@ class GoogleAnalyticsStream(Stream):
 
         # Dimensions participate in stream keys, so coerce missing values
         # to the GA-style placeholder so database loaders do not reject nulls.
-        value = (
-            "(not set)"
-            if not raw_value
-            else raw_value
-        )
+        value = "(not set)" if not raw_value else raw_value
 
         if data_type == "integer":
             return int(value)
@@ -229,14 +224,10 @@ class GoogleAnalyticsStream(Stream):
 
     def _parse_metric_value(self, metric_name: str, raw_value: t.Any) -> t.Any:
         metric_type = self._lookup_data_type(
-            "metric",
-            metric_name,
-            self.dimensions_ref,
-            self.metrics_ref
+            "metric", metric_name, self.dimensions_ref, self.metrics_ref
         )
 
-        value = raw_value.value if hasattr(
-            raw_value, "value") else raw_value
+        value = raw_value.value if hasattr(raw_value, "value") else raw_value
 
         if metric_type == "integer":
             return int(value)
@@ -256,12 +247,10 @@ class GoogleAnalyticsStream(Stream):
             dateRangeValues = row.metric_values  # noqa: N806
 
             for header, raw_dimension in zip(dimensionHeaders, dimensions):
-                record[header] = self._parse_dimension_value(
-                    header, raw_dimension)
+                record[header] = self._parse_dimension_value(header, raw_dimension)
 
             for metric_name, raw_value in zip(metricHeaders, dateRangeValues):
-                record[metric_name] = self._parse_metric_value(
-                    metric_name, raw_value)
+                record[metric_name] = self._parse_metric_value(metric_name, raw_value)
 
             # Also add the [start_date,end_date) used for the report
             record["report_start_date"] = self.config.get("start_date")
@@ -280,8 +269,7 @@ class GoogleAnalyticsStream(Stream):
             property=f"properties/{self.property_id}",
             dimensions=report_definition["dimensions"],
             metrics=report_definition["metrics"],
-            date_ranges=[
-                DateRange(start_date=state_filter, end_date=self.end_date)],
+            date_ranges=[DateRange(start_date=state_filter, end_date=self.end_date)],
             limit=self.page_size,
             metric_filter=report_definition["metricFilter"],
             dimension_filter=report_definition["dimensionFilter"],
@@ -335,8 +323,7 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "dimension", dimension, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(
-                dimension, self._get_datatype(data_type), required=True))
+            properties.append(th.Property(dimension, self._get_datatype(data_type), required=True))
             primary_keys.append(dimension)
 
         # Add the metrics to the schema
@@ -344,13 +331,11 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "metric", metric, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(
-                metric, self._get_datatype(data_type)))
+            properties.append(th.Property(metric, self._get_datatype(data_type)))
 
         properties.extend(
             (
-                th.Property("report_start_date",
-                            th.StringType(), required=True),
+                th.Property("report_start_date", th.StringType(), required=True),
                 th.Property("report_end_date", th.StringType(), required=True),
             )
         )

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -143,8 +143,7 @@ class GoogleAnalyticsStream(Stream):
 
     def _get_state_filter(self, context: Context | None) -> str:
         state = self.get_context_state(context)
-        state_bookmark = state.get(
-            "replication_key_value") or self.config["start_date"]
+        state_bookmark = state.get("replication_key_value") or self.config["start_date"]
         parsed = datetime.fromisoformat(state_bookmark).date()
         parsed = max(parsed, date(2019, 1, 1))
 
@@ -248,12 +247,10 @@ class GoogleAnalyticsStream(Stream):
             dateRangeValues = row.metric_values  # noqa: N806
 
             for header, raw_dimension in zip(dimensionHeaders, dimensions):
-                record[header] = self._parse_dimension_value(
-                    header, raw_dimension)
+                record[header] = self._parse_dimension_value(header, raw_dimension)
 
             for metric_name, raw_value in zip(metricHeaders, dateRangeValues):
-                record[metric_name] = self._parse_metric_value(
-                    metric_name, raw_value)
+                record[metric_name] = self._parse_metric_value(metric_name, raw_value)
 
             # Also add the [start_date,end_date) used for the report
             record["report_start_date"] = self.config.get("start_date")
@@ -272,8 +269,7 @@ class GoogleAnalyticsStream(Stream):
             property=f"properties/{self.property_id}",
             dimensions=report_definition["dimensions"],
             metrics=report_definition["metrics"],
-            date_ranges=[
-                DateRange(start_date=state_filter, end_date=self.end_date)],
+            date_ranges=[DateRange(start_date=state_filter, end_date=self.end_date)],
             limit=self.page_size,
             metric_filter=report_definition["metricFilter"],
             dimension_filter=report_definition["dimensionFilter"],
@@ -327,8 +323,7 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "dimension", dimension, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(
-                dimension, self._get_datatype(data_type), required=True))
+            properties.append(th.Property(dimension, self._get_datatype(data_type), required=True))
             primary_keys.append(dimension)
 
         # Add the metrics to the schema
@@ -336,13 +331,11 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "metric", metric, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(
-                metric, self._get_datatype(data_type)))
+            properties.append(th.Property(metric, self._get_datatype(data_type)))
 
         properties.extend(
             (
-                th.Property("report_start_date",
-                            th.StringType(), required=True),
+                th.Property("report_start_date", th.StringType(), required=True),
                 th.Property("report_end_date", th.StringType(), required=True),
             )
         )

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -207,6 +207,38 @@ class GoogleAnalyticsStream(Stream):
         total_rows = response.row_count
         return next_token if total_rows >= next_token * self.page_size else None
 
+    def _parse_dimension_value(self, header: str, raw_dimension: t.Any) -> t.Any:
+        data_type = self._lookup_data_type(
+            "dimension", header, self.dimensions_ref, self.metrics_ref
+        )
+
+        # Keep deviceModel in the primary key, but coerce missing values
+        # to the GA-style placeholder so Postgres does not reject nulls.
+        normalized_dimension = (
+            "(not set)"
+            if header == "deviceModel" and raw_dimension in ("", None)
+            else raw_dimension
+        )
+
+        if data_type == "integer":
+            return int(normalized_dimension)
+        if data_type == "number":
+            return float(normalized_dimension)
+        return normalized_dimension
+
+    def _parse_metric_value(self, metric_name: str, raw_value: t.Any) -> t.Any:
+        metric_type = self._lookup_data_type(
+            "metric", metric_name, self.dimensions_ref, self.metrics_ref
+        )
+
+        normalized_value = raw_value.value if hasattr(raw_value, "value") else raw_value
+
+        if metric_type == "integer":
+            return int(normalized_value)
+        if metric_type == "number":
+            return float(normalized_value)
+        return normalized_value
+
     def _parse_response(self, response):
         if not response:
             return
@@ -218,39 +250,11 @@ class GoogleAnalyticsStream(Stream):
             dimensions = [d.value for d in row.dimension_values]
             dateRangeValues = row.metric_values  # noqa: N806
 
-            for header, dimension in zip(dimensionHeaders, dimensions):
-                data_type = self._lookup_data_type(
-                    "dimension", header, self.dimensions_ref, self.metrics_ref
-                )
+            for header, raw_dimension in zip(dimensionHeaders, dimensions):
+                record[header] = self._parse_dimension_value(header, raw_dimension)
 
-                # Keep deviceModel in the primary key, but coerce missing values
-                # to the GA-style placeholder so Postgres does not reject nulls.
-                if header == "deviceModel" and dimension in ("", None):
-                    dimension = "(not set)"
-
-                if data_type == "integer":
-                    value = int(dimension)
-                elif data_type == "number":
-                    value = float(dimension)
-                else:
-                    value = dimension
-
-                record[header] = value
-
-            for metric_name, value in zip(metricHeaders, dateRangeValues):
-                metric_type = self._lookup_data_type(
-                    "metric", metric_name, self.dimensions_ref, self.metrics_ref
-                )
-
-                if hasattr(value, "value"):
-                    value = value.value  # noqa: PLW2901
-
-                if metric_type == "integer":
-                    value = int(value)  # noqa: PLW2901
-                elif metric_type == "number":
-                    value = float(value)  # noqa: PLW2901
-
-                record[metric_name] = value
+            for metric_name, raw_value in zip(metricHeaders, dateRangeValues):
+                record[metric_name] = self._parse_metric_value(metric_name, raw_value)
 
             # Also add the [start_date,end_date) used for the report
             record["report_start_date"] = self.config.get("start_date")

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -215,7 +215,7 @@ class GoogleAnalyticsStream(Stream):
 
         # Dimensions participate in stream keys, so coerce missing values
         # to the GA-style placeholder so database loaders do not reject nulls.
-        value = raw_value if raw_value else "(not set)"
+        value = raw_value or "(not set)"
 
         if data_type == "integer":
             return int(value)

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -143,7 +143,8 @@ class GoogleAnalyticsStream(Stream):
 
     def _get_state_filter(self, context: Context | None) -> str:
         state = self.get_context_state(context)
-        state_bookmark = state.get("replication_key_value") or self.config["start_date"]
+        state_bookmark = state.get(
+            "replication_key_value") or self.config["start_date"]
         parsed = datetime.fromisoformat(state_bookmark).date()
         parsed = max(parsed, date(2019, 1, 1))
 
@@ -214,7 +215,7 @@ class GoogleAnalyticsStream(Stream):
 
         # Dimensions participate in stream keys, so coerce missing values
         # to the GA-style placeholder so database loaders do not reject nulls.
-        value = "(not set)" if not raw_value else raw_value
+        value = raw_value if raw_value else "(not set)"
 
         if data_type == "integer":
             return int(value)
@@ -247,10 +248,12 @@ class GoogleAnalyticsStream(Stream):
             dateRangeValues = row.metric_values  # noqa: N806
 
             for header, raw_dimension in zip(dimensionHeaders, dimensions):
-                record[header] = self._parse_dimension_value(header, raw_dimension)
+                record[header] = self._parse_dimension_value(
+                    header, raw_dimension)
 
             for metric_name, raw_value in zip(metricHeaders, dateRangeValues):
-                record[metric_name] = self._parse_metric_value(metric_name, raw_value)
+                record[metric_name] = self._parse_metric_value(
+                    metric_name, raw_value)
 
             # Also add the [start_date,end_date) used for the report
             record["report_start_date"] = self.config.get("start_date")
@@ -269,7 +272,8 @@ class GoogleAnalyticsStream(Stream):
             property=f"properties/{self.property_id}",
             dimensions=report_definition["dimensions"],
             metrics=report_definition["metrics"],
-            date_ranges=[DateRange(start_date=state_filter, end_date=self.end_date)],
+            date_ranges=[
+                DateRange(start_date=state_filter, end_date=self.end_date)],
             limit=self.page_size,
             metric_filter=report_definition["metricFilter"],
             dimension_filter=report_definition["dimensionFilter"],
@@ -323,7 +327,8 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "dimension", dimension, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(dimension, self._get_datatype(data_type), required=True))
+            properties.append(th.Property(
+                dimension, self._get_datatype(data_type), required=True))
             primary_keys.append(dimension)
 
         # Add the metrics to the schema
@@ -331,11 +336,13 @@ class GoogleAnalyticsStream(Stream):
             data_type = self._lookup_data_type(
                 "metric", metric, self.dimensions_ref, self.metrics_ref
             )
-            properties.append(th.Property(metric, self._get_datatype(data_type)))
+            properties.append(th.Property(
+                metric, self._get_datatype(data_type)))
 
         properties.extend(
             (
-                th.Property("report_start_date", th.StringType(), required=True),
+                th.Property("report_start_date",
+                            th.StringType(), required=True),
                 th.Property("report_end_date", th.StringType(), required=True),
             )
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import datetime
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from singer_sdk.testing import get_standard_tap_tests
@@ -13,19 +13,15 @@ from tests.utilities import get_secrets_dict
 
 SAMPLE_CONFIG_SERVICE = {
     "property_id": "312647579",
-    "end_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
-    "start_date": (
-        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
-    ).isoformat(),
+    "end_date": datetime.now(timezone.utc).isoformat(),
+    "start_date": (datetime.now(timezone.utc) - timedelta(days=2)).isoformat(),
     "key_file_location": f"{os.path.dirname(__file__)}/test_data/client_secrets.json",  # noqa: PTH120
 }
 
 SAMPLE_CONFIG_CLIENT_SECRETS = {
     "property_id": "312647579",
-    "end_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
-    "start_date": (
-        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
-    ).isoformat(),
+    "end_date": datetime.now(timezone.utc).isoformat(),
+    "start_date": (datetime.now(timezone.utc) - timedelta(days=2)).isoformat(),
     "client_secrets": get_secrets_dict(),
 }
 
@@ -49,9 +45,7 @@ def test_no_credentials():
     """Run standard tap tests from the SDK."""
     SAMPLE_CONFIG_SERVICE2 = {  # noqa: N806
         "property_id": "312647579",
-        "start_date": (
-            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
-        ).isoformat(),
+        "start_date": (datetime.now(timezone.utc) - timedelta(days=2)).isoformat(),
     }
     with pytest.raises(Exception) as e:  # noqa: PT012, PT011
         tap = TapGoogleAnalytics(config=SAMPLE_CONFIG_SERVICE2)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
 import os
-from datetime import datetime, timedelta, timezone
 
 import pytest
 from singer_sdk.testing import get_standard_tap_tests
@@ -13,15 +13,19 @@ from tests.utilities import get_secrets_dict
 
 SAMPLE_CONFIG_SERVICE = {
     "property_id": "312647579",
-    "end_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-    "start_date": (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%d"),
+    "end_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+    "start_date": (
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+    ).isoformat(),
     "key_file_location": f"{os.path.dirname(__file__)}/test_data/client_secrets.json",  # noqa: PTH120
 }
 
 SAMPLE_CONFIG_CLIENT_SECRETS = {
     "property_id": "312647579",
-    "end_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-    "start_date": (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%d"),
+    "end_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+    "start_date": (
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+    ).isoformat(),
     "client_secrets": get_secrets_dict(),
 }
 
@@ -45,7 +49,9 @@ def test_no_credentials():
     """Run standard tap tests from the SDK."""
     SAMPLE_CONFIG_SERVICE2 = {  # noqa: N806
         "property_id": "312647579",
-        "start_date": (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%d"),
+        "start_date": (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+        ).isoformat(),
     }
     with pytest.raises(Exception) as e:  # noqa: PT012, PT011
         tap = TapGoogleAnalytics(config=SAMPLE_CONFIG_SERVICE2)


### PR DESCRIPTION
Since report dimensions make up the part (if not all) of a stream's primary keys, dimension values cannot be `null` when running with a database target that respects the primary key configuration (i.e. `key_properties`):

```
psycopg2.errors.NotNullViolation: null value in column "device_model" of relation "tmp_4f6bd2b9_042e_4e02_a70c_7a8d9a5f4325" violates not-null constraint
```

We should coalesce `null` values to some default - best fit may be `(not set)` to align with GA placeholder, as suggested by @acarter24 in #154.

---

Closes #154