### PR TITLE
fix: Refresh expired access token from config

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -18,7 +18,7 @@ from google.analytics.data_v1beta.types import (
 from singer_sdk import typing as th
 from singer_sdk.streams import Stream
 
-from tap_google_analytics.error import is_fatal_error
+from tap_google_analytics.error import backoff_handler, is_fatal_error
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Context
@@ -254,7 +254,13 @@ class GoogleAnalyticsStream(Stream):
 
             yield record
 
-    @backoff.on_exception(backoff.expo, (Exception), max_tries=5, giveup=is_fatal_error)
+    @backoff.on_exception(
+        backoff.expo,
+        (Exception),
+        max_tries=5,
+        on_backoff=backoff_handler,
+        giveup=is_fatal_error,
+    )
     def _query_api(self, report_definition, state_filter, pageToken=None) -> RunReportResponse:  # noqa: N803
         """Query the Analytics Reporting API V4.
 

--- a/tap_google_analytics/error.py
+++ b/tap_google_analytics/error.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import logging
 import socket
+import sys
 from typing import TYPE_CHECKING
 
 from google.api_core.exceptions import Unauthorized
@@ -99,7 +100,9 @@ def is_fatal_error(error):
 
 def backoff_handler(details: backoff.types.Details):
     """Common backoff exception handler."""
-    if not isinstance(exc := details["exception"], Unauthorized):
+    exc = sys.exc_info()[1]
+
+    if not isinstance(exc, Unauthorized):
         return
 
     # abort after initial unauthorized error

--- a/tap_google_analytics/error.py
+++ b/tap_google_analytics/error.py
@@ -96,6 +96,7 @@ def is_fatal_error(error):
     LOGGER.critical("Received fatal error %s, reason=%s, status=%s", error, reason, status)
     return True
 
+
 def backoff_handler(details: backoff.types.Details):
     """Common backoff exception handler."""
     if not isinstance(exc := details["exception"], Unauthorized):

--- a/tap_google_analytics/error.py
+++ b/tap_google_analytics/error.py
@@ -6,6 +6,14 @@ import contextlib
 import json
 import logging
 import socket
+from typing import TYPE_CHECKING
+
+from google.api_core.exceptions import Unauthorized
+
+if TYPE_CHECKING:
+    import backoff.types
+
+    from tap_google_analytics.tap import TapGoogleAnalytics
 
 
 class TapGaApiError(Exception):
@@ -76,7 +84,7 @@ def is_fatal_error(error):
         return False
 
     status = error.code if error.message is not None else None
-    if status in [500, 503]:
+    if status in [401, 500, 503]:
         return False
 
     # Use list of errors defined in:
@@ -87,3 +95,18 @@ def is_fatal_error(error):
 
     LOGGER.critical("Received fatal error %s, reason=%s, status=%s", error, reason, status)
     return True
+
+def backoff_handler(details: backoff.types.Details):
+    """Common backoff exception handler."""
+    if not isinstance(exc := details["exception"], Unauthorized):
+        return
+
+    # abort after initial unauthorized error
+    if details["tries"] > 1:
+        raise exc
+
+    tap: TapGoogleAnalytics = details["args"][0]
+
+    # no expiry implies token was provided via config, and we should attempt a refresh
+    if not tap.credentials.expiry:
+        tap.credentials.token = None

--- a/tap_google_analytics/tap.py
+++ b/tap_google_analytics/tap.py
@@ -10,6 +10,7 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import backoff
 from google.analytics.data_v1beta import BetaAnalyticsDataClient
 from google.analytics.data_v1beta.types import GetMetadataRequest
 from google.auth import exceptions
@@ -24,6 +25,7 @@ from singer_sdk import Stream, Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 from tap_google_analytics.client import GoogleAnalyticsStream
+from tap_google_analytics.error import backoff_handler, is_fatal_error
 
 if TYPE_CHECKING:
     from google.auth.transport import Request, Response
@@ -241,6 +243,13 @@ class TapGoogleAnalytics(Tap):
             self.logger.critical("'%s' file not found", report_def_file)
             sys.exit(1)
 
+    @backoff.on_exception(
+        backoff.expo,
+        (Exception),
+        max_tries=5,
+        on_backoff=backoff_handler,
+        giveup=is_fatal_error,
+    )
     def _fetch_valid_api_metadata(self) -> tuple[dict, dict]:
         """Fetch the valid (dimensions, metrics) for the Analytics Reporting API.
 


### PR DESCRIPTION
Prior to this change, `oauth_credentials.access_token` was always used if provided via config, causing `401 Unauthorized` API errors once it expired. The token is now forcibly refreshed if a `401 Unauthorized` error is encountered, via a backoff handler.